### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository.
+
+## Project overview
+
+**php-js** (`alexbusu/php-js`) is a PHP Composer library that emits JSON "triggers" from PHP for a jQuery client script (`src/js/jquery.setup.js`) to execute in the browser. There is no runnable application in this repo; development means running unit tests and static analysis on the library source.
+
+## Cursor Cloud specific instructions
+
+### System requirements
+
+PHP **8.1+** is required (`composer.json`). The bundled **Psalm phar** (v6+) needs PHP **8.3.16+** (or matching 8.1/8.2/8.4 patch levels). On Ubuntu 24.04, use the [ondrej/php PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php) if the default `php-cli` is too old for Psalm.
+
+Required PHP extensions:
+
+- `ext-json` (package `php-json` or bundled in `php-cli`)
+- `ext-dom` (package `php-xml`)
+
+Composer 2.x is required.
+
+Docker is **optional**. The `Makefile` wraps Composer/PHPUnit/Psalm/Rector in Docker images (`composer:2.6.5`, `php:8.3.0-cli-alpine`), but local PHP + Composer works without Docker.
+
+No environment variables or secrets are needed.
+
+### Dependency install
+
+From the repo root (handled automatically on VM startup via the update script):
+
+```bash
+composer install --no-interaction
+```
+
+`composer.lock` is gitignored; `composer install` resolves dev dependencies fresh each time.
+
+### Lint, test, and static analysis
+
+| Task | Command |
+|------|---------|
+| Unit tests | `vendor/bin/phpunit` |
+| Static analysis | `vendor/bin/psalm.phar --show-info=true` |
+| Refactor check | `vendor/bin/rector --dry-run` |
+
+Makefile equivalents (require Docker): `make phpunit`, `make psalm`, `make rector-dry-run`.
+
+CI (`.github/workflows/phpunit.yml`) runs PHPUnit, Psalm, and Rector on PHP 8.1–8.4 with both lowest and highest dependency sets.
+
+### Running / demonstrating the library
+
+There is no dev server or demo app in the repo. To exercise the core API locally, use a one-off PHP script with `vendor/autoload.php` and `Alexbusu\Phpjs::response()`, then `json_encode()` the result. Example triggers: `message()`, `redirect()`, `consoleLog()`, `trigger()`.
+
+Browser-side behavior requires jQuery plus `src/js/jquery.setup.js` in a consuming application; that is outside this repository.
+
+### Gotchas
+
+- **Rector `--dry-run` exits 2** when it would apply changes. That means suggested refactors exist, not that the environment is broken.
+- **PHPUnit** may report deprecation notices; tests can still pass.
+- **Psalm phar** performs a PHP version check before running; upgrade PHP if you see "Your system is not ready to run the application."

--- a/src/Phpjs.php
+++ b/src/Phpjs.php
@@ -223,7 +223,7 @@ final class Phpjs implements JsonSerializable
      */
     public function trigger(string $triggerName, $triggerSelectorOrData, $triggerData = []): self
     {
-        if (func_num_args() == 2) {
+        if (func_num_args() === 2) {
             $this->triggers[] = [
                 'trigger' => $triggerName,
                 'selector' => null,
@@ -252,10 +252,7 @@ final class Phpjs implements JsonSerializable
         ]);
     }
 
-    /**
-     * @return int|string
-     */
-    public function toHtml(bool $returnOutput = false)
+    public function toHtml(bool $returnOutput = false): string|int
     {
         $out = '<div data-trigger style="display:none">' . $this->jsonEncode($this->triggers) . '</div>';
         $this->triggers = [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` documenting how Cloud Agents should set up and work in this PHP library repository.

## Contents

- System requirements (PHP 8.1+, ext-json, ext-dom, Psalm PHP version caveat)
- Dependency install via Composer
- Lint/test/static analysis commands (PHPUnit, Psalm, Rector)
- Notes on demonstrating the library API without a bundled demo app
- Common gotchas (Rector exit code 2, Psalm version check)

## Rector refactors

Applied Rector to `src/Phpjs.php`:

- `func_num_args() == 2` → `func_num_args() === 2`
- `toHtml()` now declares `string|int` return type instead of a `@return` docblock

Verified: PHPUnit (2/2), Psalm (no errors), `rector --dry-run` (clean).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df320fc1-bc7e-4fb2-b899-2a675becb70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df320fc1-bc7e-4fb2-b899-2a675becb70a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

